### PR TITLE
Add ability to check that no message is sent

### DIFF
--- a/discord/ext/test/__init__.py
+++ b/discord/ext/test/__init__.py
@@ -3,7 +3,7 @@ __title__ = "dpytest"
 __author__ = "Rune Tynan"
 __license__ = "MIT"
 __copyright__ = "Copyright 2018-2019 CraftSpider"
-__version__ = "0.0.8"
+__version__ = "0.0.9"
 
 from . import backend
 from .runner import *

--- a/discord/ext/test/runner.py
+++ b/discord/ext/test/runner.py
@@ -41,7 +41,10 @@ def verify_message(text=None, equals=True, assert_nothing=False):
         else:
             assert message.content != text, f"Found unexpected text. Expected something not matching {text}"
     except asyncio.QueueEmpty:
-        raise AssertionError("No message returned by command")
+        if assert_nothing:
+            assert True
+        else:
+            raise AssertionError("No message returned by command")
 
 
 def verify_embed(embed=None, allow_text=False, equals=True, assert_nothing=False):

--- a/discord/ext/test/runner.py
+++ b/discord/ext/test/runner.py
@@ -35,7 +35,7 @@ def verify_message(text=None, equals=True, assert_nothing=False):
     if text is None:
         equals = not equals
     if assert_nothing:
-        assert sent_queue.qsize() == 0, f"A message was not meant to be sentbut this message was sent {sent_queue.get_nowait().content}"
+        assert sent_queue.qsize() == 0, f"A message was not meant to be sent but this message was sent {sent_queue.get_nowait().content}"
 
     try:
         message = sent_queue.get_nowait()
@@ -51,7 +51,7 @@ def verify_embed(embed=None, allow_text=False, equals=True, assert_nothing=False
     if embed is None:
         equals = not equals
     if assert_nothing:
-        assert sent_queue.qsize() == 0, f"A message was not meant to be sentbut this message was sent {sent_queue.get_nowait().content}"
+        assert sent_queue.qsize() == 0, f"A message was not meant to be sent but this message was sent {sent_queue.get_nowait().content}"
 
     try:
         message = sent_queue.get_nowait()
@@ -73,7 +73,7 @@ def verify_file(file=None, allow_text=False, equals=True, assert_nothing=False):
     if file is None:
         equals = not equals
     if assert_nothing:
-        assert sent_queue.qsize() == 0, f"A message was not meant to be sentbut this message was sent {sent_queue.get_nowait().content}"
+        assert sent_queue.qsize() == 0, f"A message was not meant to be sent but this message was sent {sent_queue.get_nowait().content}"
 
     try:
         message = sent_queue.get_nowait()

--- a/discord/ext/test/runner.py
+++ b/discord/ext/test/runner.py
@@ -34,6 +34,9 @@ async def run_all_events():
 def verify_message(text=None, equals=True, assert_nothing=False):
     if text is None:
         equals = not equals
+    if assert_nothing:
+        assert sent_queue.qsize() == 0, f"A message was not meant to be sentbut this message was sent {sent_queue.get_nowait().content}"
+
     try:
         message = sent_queue.get_nowait()
         if equals:
@@ -41,15 +44,15 @@ def verify_message(text=None, equals=True, assert_nothing=False):
         else:
             assert message.content != text, f"Found unexpected text. Expected something not matching {text}"
     except asyncio.QueueEmpty:
-        if assert_nothing:
-            assert True
-        else:
-            raise AssertionError("No message returned by command")
+        raise AssertionError("No message returned by command")
 
 
 def verify_embed(embed=None, allow_text=False, equals=True, assert_nothing=False):
     if embed is None:
         equals = not equals
+    if assert_nothing:
+        assert sent_queue.qsize() == 0, f"A message was not meant to be sentbut this message was sent {sent_queue.get_nowait().content}"
+
     try:
         message = sent_queue.get_nowait()
         if not allow_text:
@@ -63,15 +66,15 @@ def verify_embed(embed=None, allow_text=False, equals=True, assert_nothing=False
         else:
             assert emb != embed, "Found unexpected embed"
     except asyncio.QueueEmpty:
-        if assert_nothing:
-            assert True
-        else:
-            raise AssertionError("No message returned by command")
+        raise AssertionError("No message returned by command")
 
 
 def verify_file(file=None, allow_text=False, equals=True, assert_nothing=False):
     if file is None:
         equals = not equals
+    if assert_nothing:
+        assert sent_queue.qsize() == 0, f"A message was not meant to be sentbut this message was sent {sent_queue.get_nowait().content}"
+
     try:
         message = sent_queue.get_nowait()
         if not allow_text:
@@ -85,10 +88,7 @@ def verify_file(file=None, allow_text=False, equals=True, assert_nothing=False):
         else:
             assert attach != file, "Found unexpected file"
     except asyncio.QueueEmpty:
-        if assert_nothing:
-            assert True
-        else:
-            raise AssertionError("No message returned by command")
+        raise AssertionError("No message returned by command")
 
 
 def verify_activity(activity=None, equals=True):

--- a/discord/ext/test/runner.py
+++ b/discord/ext/test/runner.py
@@ -31,7 +31,7 @@ async def run_all_events():
             await task
 
 
-def verify_message(text=None, equals=True):
+def verify_message(text=None, equals=True, assert_nothing=False):
     if text is None:
         equals = not equals
     try:
@@ -44,7 +44,7 @@ def verify_message(text=None, equals=True):
         raise AssertionError("No message returned by command")
 
 
-def verify_embed(embed=None, allow_text=False, equals=True):
+def verify_embed(embed=None, allow_text=False, equals=True, assert_nothing=False):
     if embed is None:
         equals = not equals
     try:
@@ -60,10 +60,13 @@ def verify_embed(embed=None, allow_text=False, equals=True):
         else:
             assert emb != embed, "Found unexpected embed"
     except asyncio.QueueEmpty:
-        raise AssertionError("No message returned by command")
+        if assert_nothing:
+            assert True
+        else:
+            raise AssertionError("No message returned by command")
 
 
-def verify_file(file=None, allow_text=False, equals=True):
+def verify_file(file=None, allow_text=False, equals=True, assert_nothing=False):
     if file is None:
         equals = not equals
     try:
@@ -79,7 +82,10 @@ def verify_file(file=None, allow_text=False, equals=True):
         else:
             assert attach != file, "Found unexpected file"
     except asyncio.QueueEmpty:
-        raise AssertionError("No message returned by command")
+        if assert_nothing:
+            assert True
+        else:
+            raise AssertionError("No message returned by command")
 
 
 def verify_activity(activity=None, equals=True):


### PR DESCRIPTION
added parameter 'assert_nothing' to 'verify_embed' and 'verify_message' so that you can check that the bot does not respond to certain messages