### PR TITLE
Add regex to detect mentions

### DIFF
--- a/discord/ext/test/backend.py
+++ b/discord/ext/test/backend.py
@@ -5,6 +5,7 @@
 import asyncio
 import sys
 import logging
+import re
 import typing
 import pathlib
 import discord
@@ -430,7 +431,11 @@ def delete_member(member):
 
 def make_message(content, author, channel, id_num=-1):
     guild_id = channel.guild.id if channel.guild else None
-    data = facts.make_message_dict(channel, author, id_num, content=content, guild_id=guild_id)
+
+    mentions = find_mentions(content, channel.guild)
+
+    data = facts.make_message_dict(channel, author, id_num, content=content,
+                                   mentions=mentions, guild_id=guild_id)
 
     state = get_state()
     state.parse_message_create(data)
@@ -441,6 +446,10 @@ def make_message(content, author, channel, id_num=-1):
 
     return state._get_message(data["id"])
 
+
+def find_mentions(content, guild):
+    matches = re.findall(r"<@[0-9]{18}>", content, re.MULTILINE)
+    return [discord.utils.get(guild.members, mention=match) for match in matches]  # noqa: E501
 
 def delete_message(message):
     data = {


### PR DESCRIPTION
Hi !

Fist of all, thanks for the lib ! It's really cool to be able to unit test his cogs, etc...

I propose this PR.

##  Why this PR ?

I had troubles testing commands that use a mention, like `!kick @bad_user` or !greet @user`.
I was able to get the <@XXXXXXXXX> mention string, and form my message, in my unit test, but it was just the "content" string of the message. The `mentions` wasn't filled.

##  What it changes :
I added a regex, to detect <@mentions> and fill the mentions field of the Message object.

##  Discussions
I added this to the `backend.py` file, but I'm not sure if it's the right place.