### PR TITLE
DM Channel

### DIFF
--- a/tests/dm_channel_pytest.py
+++ b/tests/dm_channel_pytest.py
@@ -1,0 +1,55 @@
+import discord
+import pytest
+from discord import DMChannel, Guild, Member, TextChannel, User
+from discord.ext.commands import Bot
+
+from ..discord.ext.test import runner
+
+
+@pytest.mark.asyncio
+async def test_can_send_dm():
+    """
+    Tests, that a message directly can be sent to a user/member.
+    Discord creates a DM Channel in the background
+    """
+    bot = Bot("!")
+    runner.configure(bot)
+    g: Guild = bot.guilds[0]
+    m: Member = g.members[0]
+    assert isinstance(m, discord.abc.User), "participant must be a user (not channel)"
+    await m.send("this is a dm!")
+    runner.verify_message("this is a dm!")
+
+
+@pytest.mark.asyncio
+async def test_bot_can_receive_dm():
+    """
+    Tests, that a bot can receive a message directly from a user/member
+    """
+    bot = Bot("!")
+    bot.load_extension('tests.internal.cogs.echo')
+    runner.configure(bot)
+    g: Guild = bot.guilds[0]
+    m: User = g.members[0]
+    assert isinstance(m, discord.abc.User), "participant must be a user (not channel)"
+    dm = m.dm_channel or (await m.create_dm())
+    assert dm
+    assert isinstance(dm, DMChannel)
+    await runner.message("!origin_channel_type", channel=dm, member=m)
+    runner.verify_message(str(DMChannel))
+
+@pytest.mark.asyncio
+async def test_bot_receive_guild_reply_dm():
+    """
+    Tests, that a bot can receive a message in a guild,
+    and directly reply to a user/member via dm
+    """
+    bot = Bot("!")
+    bot.load_extension('tests.internal.cogs.echo')
+    runner.configure(bot)
+    g: Guild = bot.guilds[0]
+    m: User = g.members[0]
+    c: TextChannel = g.channels[0]
+    await runner.message("!echo_dm this is a dm reply!", channel=c, member=m)
+    assert isinstance(m, discord.abc.User), "participant must be a user (not channel)"
+    runner.verify_message("this is a dm reply!")

--- a/tests/internal/cogs/echo.py
+++ b/tests/internal/cogs/echo.py
@@ -1,12 +1,19 @@
 import discord
-from discord.ext.commands import Bot, Cog, command, Context
+from discord.ext.commands import Bot, Cog, Context, command
 
 
 class Echo(Cog):
     @command()
-    async def echo(self, ctx: Context, text: str):
+    async def echo(self, ctx: Context, *, text: str):
         await ctx.send(text)
 
+    @command()
+    async def echo_dm(self, ctx: Context, *, text: str):
+        await ctx.author.send(text)
+
+    @command()
+    async def origin_channel_type(self, ctx: Context):
+        await ctx.send(str(type(ctx.channel)))
 
 def setup(bot: Bot):
     bot.add_cog(Echo())


### PR DESCRIPTION
will close #7 

At this stage, you can send, receive and verify DMs. 

Should there also be:
1. an explicit way to differentiate between DMs and GuildTextChannels in verify_*?
2. a global list of all DM-Channels in `RunnerConfig`?