### PR TITLE
Add content type to attachments

### DIFF
--- a/discord/ext/test/factories.py
+++ b/discord/ext/test/factories.py
@@ -298,12 +298,12 @@ def make_attachment_dict(filename, size, url, proxy_url, id_num=-1, height=None,
         id_num = make_id()
     return {
         'id': id_num,
-        'size': size,
-        'height': height,
-        'width': width,
         'filename': filename,
+        'size': size,
         'url': url,
         'proxy_url': proxy_url,
+        'height': height,
+        'width': width,
         'content_type': content_type
     }
 

--- a/discord/ext/test/factories.py
+++ b/discord/ext/test/factories.py
@@ -293,17 +293,18 @@ def dict_from_message(message: discord.Message):
     return out
 
 
-def make_attachment_dict(filename, size, url, proxy_url, id_num=-1, height=None, width=None):
+def make_attachment_dict(filename, size, url, proxy_url, id_num=-1, height=None, width=None, content_type=None):
     if id_num < 0:
         id_num = make_id()
     return {
         'id': id_num,
-        'filename': filename,
         'size': size,
+        'height': height,
+        'width': width,
+        'filename': filename,
         'url': url,
         'proxy_url': proxy_url,
-        'height': height,
-        'width': width
+        'content_type': content_type
     }
 
 

--- a/discord/ext/test/state.py
+++ b/discord/ext/test/state.py
@@ -45,3 +45,9 @@ class FakeState(dstate.ConnectionState):
 
     async def chunk_guild(self, *args, **kwargs):
         pass
+
+    def _guild_needs_chunking(self, guild):
+        """
+        Prevents chunking which can throw asyncio wait_for errors with tests under 60 seconds
+        """
+        return False

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -16,7 +16,7 @@ async def test_member_join(bot):
                                                                                                  "https://media.discordapp.net/attachments/some_number/random_number/test.jpg",
                                                                                                  "https://media.discordapp.net/attachments/some_number/random_number/test.jpg",
                                                                                                  height=1000,
-                                                                                                 width=1000))
+                                                                                                 width=1000, content_type="image/jpeg"))
     message_dict = dpytest.back.facts.make_message_dict(channel, author, attachments=[attach])
     try:
         message: discord.Message = discord.Message(state=dpytest.back.get_state(), channel=channel, data=message_dict)


### PR DESCRIPTION
New to discord.py 1.7 is 'content_type' for attachments

This adds an optional param to the make_attachment_dict factory 