### PR TITLE
Fix runner reaction handling

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.3.0
+
+- Rename simulate_reaction -> add_reaction and make it take a user to react as
+
 ## 0.2.0
 
 - Merge hint files into .py files

--- a/discord/ext/test/backend.py
+++ b/discord/ext/test/backend.py
@@ -743,7 +743,7 @@ def make_attachment(filename: pathlib.Path, name: typing.Optional[str] = None, i
     )
 
 
-def add_reaction(message: discord.Message, user: discord.User, emoji: str) -> None:
+def add_reaction(message: discord.Message, user: typing.Union[discord.user.BaseUser, discord.abc.User], emoji: str) -> None:
     if ":" in emoji:
         temp = emoji.split(":")
         emoji = {

--- a/discord/ext/test/runner.py
+++ b/discord/ext/test/runner.py
@@ -361,16 +361,16 @@ async def remove_role(member: discord.Member, role: discord.Role) -> None:
     back.update_member(member, roles=roles)
 
 
-# self is a discord.Message based on how this framework runs
-async def simulate_reaction(self: discord.Message, emoji: str, member: discord.Member):
-
-    state = back.get_state()
-    await state.http.add_reaction(self.channel.id, self.id, emoji)
+@require_config
+async def add_reaction(user: typing.Union[discord.user.BaseUser, discord.abc.User], message: discord.Message, emoji: str) -> None:
+    back.add_reaction(message, user, emoji)
     await run_all_events()
 
-    if not error_queue.empty():
-        err = await error_queue.get()
-        raise err[1]
+
+@require_config
+async def remove_reaction(user: typing.Union[discord.user.BaseUser, discord.abc.User], message: discord.Message, emoji: str) -> None:
+    back.remove_reaction(message, user, emoji)
+    await run_all_events()
 
 
 @require_config

--- a/discord/ext/test/runner.py
+++ b/discord/ext/test/runner.py
@@ -363,12 +363,26 @@ async def remove_role(member: discord.Member, role: discord.Role) -> None:
 
 @require_config
 async def add_reaction(user: typing.Union[discord.user.BaseUser, discord.abc.User], message: discord.Message, emoji: str) -> None:
+    """
+        Add a reaction to a message, as if added by another user
+
+    :param user: User who reacted
+    :param message: Message they reacted to
+    :param emoji: Emoji that was used
+    """
     back.add_reaction(message, user, emoji)
     await run_all_events()
 
 
 @require_config
 async def remove_reaction(user: typing.Union[discord.user.BaseUser, discord.abc.User], message: discord.Message, emoji: str) -> None:
+    """
+        Remove a reaction from a message, as if done by another user
+
+    :param user: User who removed their react
+    :param message: Message they removed react from
+    :param emoji: Emoji that was removed
+    """
     back.remove_reaction(message, user, emoji)
     await run_all_events()
 

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -1,4 +1,5 @@
 import pytest
+import discord.ext.test as dpytest
 
 
 @pytest.mark.asyncio
@@ -25,3 +26,38 @@ async def test_remove_reaction(bot):
 
     message = await c.fetch_message(message.id)
     assert len(message.reactions) == 0
+
+
+@pytest.mark.asyncio
+async def test_user_add_reaction(bot):
+    g = bot.guilds[0]
+    c = g.text_channels[0]
+    m = g.members[0]
+
+    message = await c.send("Test Message")
+    await dpytest.add_reaction(m, message, "😂")
+
+    # Assumes the above tests pass
+    message = await c.fetch_message(message.id)
+    react = message.reactions[0]
+    assert react.emoji == "😂"
+    assert react.me is False
+
+
+@pytest.mark.asyncio
+async def test_user_remove_reaction(bot):
+    g = bot.guilds[0]
+    c = g.text_channels[0]
+    m = g.members[0]
+
+    message = await c.send("Test Message")
+    await message.add_reaction("😂")
+    await dpytest.add_reaction(m, message, "😂")
+    await dpytest.remove_reaction(m, message, "😂")
+
+    # Assumes the above tests pass
+    message = await c.fetch_message(message.id)
+    react = message.reactions[0]
+    assert react.emoji == "😂"
+    assert react.count == 1
+    assert react.me is True


### PR DESCRIPTION
Previous function name didn't match the standard, and behaved unlike other methods in `runner` by being from the bot, which can already be done just fine by the user via `message.add_reaction`. Kept the `run_all_events` as it might be useful.