### PR TITLE
Get member mentions by using the user ID in mention

### DIFF
--- a/discord/ext/test/backend.py
+++ b/discord/ext/test/backend.py
@@ -733,7 +733,7 @@ def find_user_mentions(content: typing.Optional[str], guild: typing.Optional[dis
     if guild is None or content is None:
         return []  # TODO: Check for dm user mentions
     matches = re.findall(MEMBER_MENTION, content)
-    return [discord.utils.get(guild.members, mention=match) for match in matches]  # noqa: E501
+    return [discord.utils.get(guild.members, id=int(re.search(r'\d+', match)[0])) for match in matches]  # noqa: E501
 
 
 def find_role_mentions(content: typing.Optional[str], guild: typing.Optional[discord.Guild]) -> typing.List[int]:

--- a/discord/ext/test/runner.py
+++ b/discord/ext/test/runner.py
@@ -570,6 +570,8 @@ def configure(client: discord.Client, num_guilds: int = 1, num_channels: int = 1
             user = back.make_user(f"TestUser{str(num)}", f"{num+1:04}")
             member = back.make_member(user, guild, nick=user.name + f"_{str(num)}_nick")
             members.append(member)
+        client_member = back.make_member(client.user, guild, nick=client.user.name + f"_nick")
+        members.append(client_member)
         back.make_member(back.get_state().user, guild)
 
     back.get_state().start_dispatch()

--- a/discord/ext/test/runner.py
+++ b/discord/ext/test/runner.py
@@ -570,9 +570,7 @@ def configure(client: discord.Client, num_guilds: int = 1, num_channels: int = 1
             user = back.make_user(f"TestUser{str(num)}", f"{num+1:04}")
             member = back.make_member(user, guild, nick=user.name + f"_{str(num)}_nick")
             members.append(member)
-        client_member = back.make_member(client.user, guild, nick=client.user.name + f"_nick")
-        members.append(client_member)
-        back.make_member(back.get_state().user, guild)
+        back.make_member(back.get_state().user, guild, nick=client.user.name + f"_nick")
 
     back.get_state().start_dispatch()
 

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -42,3 +42,15 @@ async def test_channel_mention(bot):
     mes = await test.message("Not a mention in sight")
 
     assert len(mes.channel_mentions) == 0
+
+
+@pytest.mark.asyncio
+async def test_bot_mention(bot):
+    mes = await test.message(f"<@{bot.user.id}>")
+
+    assert len(mes.mentions) == 1
+    assert mes.mentions[0] == bot.user
+
+    mes = await test.message("Not a mention in sight")
+
+    assert len(mes.mentions) == 0


### PR DESCRIPTION
Bot clients are not being added as a member to the guilds, because of this when you mention the bot user discord.util.get returns null

Reproduction:

```python
@pytest.mark.asyncio
async def test_hello_mention(bot):
    message = await dpytest.message(f"hello <@{bot.user.id}>")
    dpytest.verify_message(f"<@{message.author.id}>, get to work!")
```
Will cascade into:
```python
return [discord.utils.get(guild.members, mention=match) for match in matches]
```
Which will return `[None]`.

This PR contains a simple fix that adds the bot client to any guilds that are initialised with runner.configure