### PR TITLE
Fix behaviour when I use 'discord.Role.edit' with hoist, mentionable, etc.

### DIFF
--- a/discord/ext/test/backend.py
+++ b/discord/ext/test/backend.py
@@ -366,7 +366,7 @@ class FakeHttp(dhttp.HTTPClient):
 
         await callbacks.dispatch_event("edit_role", guild, role, fields, reason=reason)
 
-        update_role(role, **fields)        
+        update_role(role, **fields)
         return facts.dict_from_role(role)
 
     async def delete_role(self, guild_id: int, role_id: int, *, reason: typing.Optional[str] = None) -> None:
@@ -647,7 +647,7 @@ def update_role(
         data["role"]["mentionable"] = mentionable
     if name is not None:
         data["role"]["name"] = name
-        
+
     state = get_state()
     state.parse_guild_role_update(data)
 

--- a/discord/ext/test/backend.py
+++ b/discord/ext/test/backend.py
@@ -366,7 +366,7 @@ class FakeHttp(dhttp.HTTPClient):
 
         await callbacks.dispatch_event("edit_role", guild, role, fields, reason=reason)
 
-        update_role(role, **fields)
+        update_role(role, **fields)        
         return facts.dict_from_role(role)
 
     async def delete_role(self, guild_id: int, role_id: int, *, reason: typing.Optional[str] = None) -> None:
@@ -636,16 +636,18 @@ def update_role(
     if color is not None:
         colour = color
     if colour is not None:
-        data["color"] = colour
+        data["role"]["color"] = colour
     if permissions is not None:
-        data["permissions"] = permissions
+        data["role"]["permissions"] = int(permissions)
+        data["role"]["permissions_new"] = int(permissions)
+
     if hoist is not None:
-        data["hoist"] = hoist
+        data["role"]["hoist"] = hoist
     if mentionable is not None:
-        data["mentionable"] = mentionable
+        data["role"]["mentionable"] = mentionable
     if name is not None:
         data["role"]["name"] = name
-
+        
     state = get_state()
     state.parse_guild_role_update(data)
 

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -18,11 +18,14 @@ async def test_edit_role(bot):
     await bot.guilds[0].create_role(name="TestRole")  # Role object
     assert len(bot.guilds[0].roles) == 3
     staff_role = bot.guilds[0].roles[1]
-    await staff_role.edit(position=2)
+    await staff_role.edit(permissions=discord.Permissions(8), colour=discord.Color.red(), hoist=True, mentionable=True, position=2)
     assert bot.guilds[0].roles[2] == staff_role
+    assert bot.guilds[0].roles[2].colour == discord.Color.red()
+    assert bot.guilds[0].roles[2].hoist is True
+    assert bot.guilds[0].roles[2].mentionable is True
+    assert bot.guilds[0].roles[2].permissions.administrator is True
     #assert staff_role in member1.roles
-
-
+    
 @pytest.mark.asyncio
 async def test_remove_role(bot):
     guild = bot.guilds[0]


### PR DESCRIPTION
When I used `discord.Role.edit()` method, dpytest ignored the change of role.
I wrote test like below today:

```py
await guild.create_role(name="role")
role = bot.guilds[0].roles[1]
await role.edit(hoist=True)

assert bot.guilds[0].roles[1].hoist is True
```

But the test failed because `roles[1].hoist` is False.