### PR TITLE
Add discord.py version notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Notice: this package does not currently support discord.py 2.0.0
+
+This project has been on pause since the 2.0.0 rewrites.
+
+---
+
 # dpytest
 
 [![Build Status](https://travis-ci.com/CraftSpider/dpytest.svg?branch=master)](https://travis-ci.com/CraftSpider/dpytest)


### PR DESCRIPTION
I just found this library while looking for a way to automate tests on my bot. I saw that it hadn't been updated in around a year (since the rewrites), and after joining y'all's Discord, I saw that v2.0.0 isn't currently supported. I figured it'd be nice to add a notice to the repository for others looking for a way to test their bots.