### PR TITLE
Improve CI and remove Travis CI completely

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -11,8 +11,6 @@ jobs:
     name: Create Draft Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -26,7 +26,6 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-        cache: pip # enables caching for faster installs (i guess)
     - name: Update pip
       run: python -m pip install --upgrade pip
       

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -1,0 +1,39 @@
+# This workflow is a reimplementation of the workflow for Travis CI: Tests dpytest.
+# Runs every push on any branch and on a PR targeting "master"
+
+name: Test CI
+
+on:
+  push:
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      # don't cancel any remaning jobs when one fails
+      fail-fast: false
+      # how you define a matrix strategy
+      matrix:
+        # use these pythons
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: pip # enables caching for faster installs (i guess)
+    - name: Update pip
+      run: python -m pip install --upgrade pip
+      
+    - name: Install dev dependencies
+      run: python -m pip install -r dev-requirements.txt
+    - name: Install self (dpytest)
+      run: python -m pip install .
+        
+    - name: Test with pytest
+      run: pytest

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -26,13 +26,11 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Update pip
-      run: python -m pip install --upgrade pip
       
     - name: Install dev dependencies
       run: python -m pip install -r dev-requirements.txt
     - name: Install self (dpytest)
       run: python -m pip install .
         
-    - name: Test with pytest
-      run: pytest
+    - name: Test
+      run: inv test

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -32,5 +32,5 @@ jobs:
     - name: Install self (dpytest)
       run: python -m pip install .
         
-    - name: Test
-      run: inv test
+    - name: Test with pytest
+      run: pytest


### PR DESCRIPTION
I intend this PR to phase out [Travis CI](https://travis-ci.com) and replace it with [GitHub Actions](https://github.com/features/actions) completely, as Travis CI doesn't have a free tier anymore.
GitHub Actions still has one (and probably only limited to the max for everyone (way high))