### PR TITLE
Improve CI, report coverage (correctly) and more

### DIFF
--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -17,6 +17,10 @@ jobs:
       uses: actions/setup-python@v3.1.2
       with:
         python-version: "3.11"
+        cache: 'pip'
+        cache-dependency-path: |
+          dev-requirements.txt
+          setup.py
       
     - name: Install dev dependencies
       run: python -m pip install -r dev-requirements.txt

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -24,8 +24,6 @@ jobs:
       
     - name: Install dev dependencies
       run: python -m pip install -r dev-requirements.txt
-    - name: Install self (dpytest)
-      run: python -m pip install .
 
     - name: Lint
       run: python -m flake8 discord/ext/test tests/ tasks.py

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  push:
+    paths-ignore: [ "docs/*", "*.md", ".readthedocs.yml", ".github/dependabot.yml", ".vscode" ]
+  pull_request:
+    paths-ignore: [ "docs/*", "*.md", ".readthedocs.yml", ".github/dependabot.yml", ".vscode" ]
+    branches: [ "master" ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v3.1.2
+      with:
+        python-version: "3.11"
+      
+    - name: Install dev dependencies
+      run: python -m pip install -r dev-requirements.txt
+    - name: Install self (dpytest)
+      run: python -m pip install .
+
+    - name: Lint
+      run: python -m flake8 discord/ext/test tests/ tasks.py

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -1,7 +1,8 @@
 # This workflow is a re-implementation of the workflow for Travis CI: Tests dpytest.
+# NEW: Now also lints code
 # Runs every push on any branch and on a PR targeting "master"
 
-name: Test CI
+name: Python CI
 
 on:
   push:
@@ -11,7 +12,7 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
     strategy:
@@ -63,4 +64,21 @@ jobs:
         name: ${{ matrix.python-version }}-cov-lcov
         path: coverage.lcov
         if-no-files-found: warn
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v3.1.2
+      with:
+        python-version: "3.11"
       
+    - name: Install dev dependencies
+      run: python -m pip install -r dev-requirements.txt
+    - name: Install self (dpytest)
+      run: python -m pip install .
+
+    - name: lint
+      run: python -m flake8 discord/ext/test tests/ tasks.py

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v3.1.2
       with:
         python-version: ${{ matrix.python-version }}
       
@@ -34,5 +34,10 @@ jobs:
     - name: Install self (dpytest)
       run: python -m pip install .
         
-    - name: Test with pytest
-      run: python -m pytest
+    #- name: Test with pytest
+    #  run: python -m pytest
+    
+    - name: Test with pytest and coverage
+      run: coverage run --source=discord/ext/test -m pytest
+    - name: Report coverage
+      run: coverage report

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -38,6 +38,6 @@ jobs:
     #  run: python -m pytest
     
     - name: Test with pytest and coverage
-      run: coverage run --source=discord/ext/test -m pytest
+      run: coverage run --source=discord.ext.test -m pytest
     - name: Report coverage
       run: coverage report

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -1,5 +1,4 @@
 # This workflow is a re-implementation of the workflow for Travis CI: Tests dpytest.
-# NEW: Now also lints code
 # Runs every push on any branch and on a PR targeting "master"
 
 name: Test CI

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -81,4 +81,4 @@ jobs:
       run: python -m pip install .
 
     - name: lint
-      run: python -m flake8 discord/ext/test tests/ tasks.py
+      run: flake8 discord/ext/test tests/ tasks.py

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -6,9 +6,9 @@ name: Python CI
 
 on:
   push:
-    paths-ignore: [ "docs/*", "*.md", ".readthedocs.yml", ".github/dependabot.yml" ]
+    paths-ignore: [ "docs/*", "*.md", ".readthedocs.yml", ".github/dependabot.yml", ".vscode" ]
   pull_request:
-    paths-ignore: [ "docs/*", "*.md", ".readthedocs.yml", ".github/dependabot.yml" ]
+    paths-ignore: [ "docs/*", "*.md", ".readthedocs.yml", ".github/dependabot.yml", ".vscode" ]
     branches: [ "master" ]
 
 jobs:
@@ -80,5 +80,5 @@ jobs:
     - name: Install self (dpytest)
       run: python -m pip install .
 
-    - name: lint
+    - name: Lint
       run: python -m flake8 discord/ext/test tests/ tasks.py

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -2,7 +2,7 @@
 # NEW: Now also lints code
 # Runs every push on any branch and on a PR targeting "master"
 
-name: Python CI
+name: Test CI
 
 on:
   push:
@@ -65,20 +65,3 @@ jobs:
         path: coverage.lcov
         if-no-files-found: warn
 
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v3.1.2
-      with:
-        python-version: "3.11"
-      
-    - name: Install dev dependencies
-      run: python -m pip install -r dev-requirements.txt
-    - name: Install self (dpytest)
-      run: python -m pip install .
-
-    - name: Lint
-      run: python -m flake8 discord/ext/test tests/ tasks.py

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -40,4 +40,27 @@ jobs:
     - name: Test with pytest and coverage
       run: coverage run --source=discord.ext.test -m pytest
     - name: Report coverage
-      run: coverage report
+      run: |
+        coverage report
+        coverage html
+        coverage xml
+        coverage lcov
+    - name: Upload HTML report
+      uses: actions/upload-artifact@v3.1.1
+      with:
+        name: ${{ matrix.python-version }}-cov-htmlcov
+        path: htmlcov
+        if-no-files-found: warn
+    - name: Upload XML report
+      uses: actions/upload-artifact@v3.1.1
+      with:
+        name: ${{ matrix.python-version }}-cov-xml
+        path: coverage.xml
+        if-no-files-found: warn
+    - name: Upload LCOV report
+      uses: actions/upload-artifact@v3.1.1
+      with:
+        name: ${{ matrix.python-version }}-cov-lcov
+        path: coverage.lcov
+        if-no-files-found: warn
+      

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -38,7 +38,7 @@ jobs:
     #  run: python -m pytest
     
     - name: Test with pytest and coverage
-      run: python -m invoke coverage
+      run: coverage run --source=discord/ext/test -m pytest
     - name: Report coverage
       run: |
         coverage report

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -38,7 +38,7 @@ jobs:
     #  run: python -m pytest
     
     - name: Test with pytest and coverage
-      run: python -m inv coverage
+      run: python -m invoke coverage
     - name: Report coverage
       run: |
         coverage report

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -70,10 +70,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v3.1.2
       with:
-        python-version: "3.10"
+        python-version: "3.11"
       
     - name: Install dev dependencies
       run: python -m pip install -r dev-requirements.txt
@@ -81,4 +81,4 @@ jobs:
       run: python -m pip install .
 
     - name: lint
-      run: flake8 discord/ext/test tests/ tasks.py
+      run: python -m flake8 discord/ext/test tests/ tasks.py

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -1,4 +1,4 @@
-# This workflow is a reimplementation of the workflow for Travis CI: Tests dpytest.
+# This workflow is a re-implementation of the workflow for Travis CI: Tests dpytest.
 # Runs every push on any branch and on a PR targeting "master"
 
 name: Test CI
@@ -15,7 +15,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-      # don't cancel any remaning jobs when one fails
+      # don't cancel any remaining jobs when one fails
       fail-fast: false
       # how you define a matrix strategy
       matrix:
@@ -38,7 +38,7 @@ jobs:
     #  run: python -m pytest
     
     - name: Test with pytest and coverage
-      run: coverage run --source=discord.ext.test -m pytest
+      run: python -m inv coverage
     - name: Report coverage
       run: |
         coverage report

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -28,6 +28,10 @@ jobs:
       uses: actions/setup-python@v3.1.2
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: |
+          dev-requirements.txt
+          setup.py
       
     - name: Install dev dependencies
       run: python -m pip install -r dev-requirements.txt

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -5,7 +5,9 @@ name: Test CI
 
 on:
   push:
+    paths-ignore: [ "docs/*", "*.md", ".readthedocs.yml", ".github/dependabot.yml" ]
   pull_request:
+    paths-ignore: [ "docs/*", "*.md", ".readthedocs.yml", ".github/dependabot.yml" ]
     branches: [ "master" ]
 
 jobs:
@@ -33,4 +35,4 @@ jobs:
       run: python -m pip install .
         
     - name: Test with pytest
-      run: pytest
+      run: python -m pytest

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -70,10 +70,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.11
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3.1.2
       with:
-        python-version: "3.11"
+        python-version: "3.10"
       
     - name: Install dev dependencies
       run: python -m pip install -r dev-requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,5 @@ ENV/
 env.bak/
 venv.bak/
 
-# IDE files
-/.vscode
-
 # Secrets files (tokens, etc...)
 /.pypirc

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-python.flake8"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "flake8.importStrategy": "fromEnvironment",
+    
+}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 sphinx>=3
 pytest
 pytest-asyncio
-coverage
+coverage~=6.5.0
 discord.py==2.1.0
 invoke
 sphinx-automodapi

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,4 @@ discord.py==2.1.0
 invoke
 sphinx-automodapi
 build
+flake8~=6.0.0


### PR DESCRIPTION
I intend this PR to improve the Test CI workflow a bit.

- It should only run when code is changed (not just on every push on anything)
- It also reports coverage and uploads it in multiple formats

It also seems like coverage doesn't pick up the files when provided whereas if it's a path. (`--source=discord/ext/test` collects nothing)
I examined the source code and tried passing `discord.ext.test` to `--source`, which worked and was able to collect data.
However, the filenames in the report are pointing inside the Python installation being used, which when used with a service that tracks code coverage, may mess things up.

Should I figure out how to remove those things automatically? coverage also has an [API for modifying the DB](https://coverage.readthedocs.io/en/6.5.0/api_coveragedata.html#coverage.CoverageData).
