### PR TITLE
Refactor imports in __init__.py

### DIFF
--- a/discord/ext/test/__init__.py
+++ b/discord/ext/test/__init__.py
@@ -5,7 +5,16 @@ __license__ = "MIT"
 __copyright__ = "Copyright 2018-2019 CraftSpider"
 __version__ = "0.6.3"
 
-from . import backend
+from . import backend as backend
+
 from .runner import *
-from .utils import embed_eq, activity_eq, embed_proxy_eq, PeekableQueue
-from .verify import verify, Verify, VerifyMessage, VerifyActivity
+
+from .utils import embed_eq as embed_eq
+from .utils import activity_eq as activity_eq
+from .utils import embed_proxy_eq as embed_proxy_eq
+from .utils import PeekableQueue as PeekableQueue
+
+from .verify import verify as verify
+from .verify import Verify as Verify
+from .verify import VerifyMessage as VerifyMessage
+from .verify import VerifyActivity as VerifyActivity


### PR DESCRIPTION
Refactor imports to use explicit exports as per[ PEP 484](https://peps.python.org/pep-0484/#stub-files).

> Modules and variables imported into the stub are not considered exported from the stub unless the import uses the `import ... as ...` form or the equivalent `from ... import ... as ...` form.

This prevents strict type checker's from giving the `"x" is not exported from module "y"` warnings.