### PR TITLE
Added support for creating and joining voice channels

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,3 +7,4 @@ invoke
 sphinx-automodapi
 build
 flake8~=6.0.0
+pynacl

--- a/discord/ext/test/factories.py
+++ b/discord/ext/test/factories.py
@@ -8,6 +8,7 @@ import datetime as dt
 import discord
 from . import _types
 
+
 generated_ids: int = 0
 
 
@@ -265,6 +266,10 @@ def make_dm_channel_dict(user: discord.User, id_num: int = -1, **kwargs: typing.
     return make_channel_dict(discord.ChannelType.private, id_num, recipients=[dict_from_user(user)], **kwargs)
 
 
+def make_voice_channel_dict(name: str, id_num: int = -1, **kwargs: typing.Any) -> _types.JsonDict:
+    return make_channel_dict(discord.ChannelType.voice.value, id_num, name=name, **kwargs)
+
+
 def dict_from_overwrite(target: typing.Union[discord.Member, discord.Role],
                         overwrite: discord.PermissionOverwrite) -> _types.JsonDict:
     allow, deny = overwrite.pair()
@@ -295,6 +300,15 @@ def dict_from_channel(channel: _types.AnyChannel) -> _types.JsonDict:
             'parent_id': channel.category_id
         }
     if isinstance(channel, discord.CategoryChannel):
+        return {
+            'name': channel.name,
+            'position': channel.position,
+            'id': channel.id,
+            'guild_id': channel.guild.id,
+            'permission_overwrites': [dict_from_overwrite(k, v) for k, v in channel.overwrites.items()],
+            'type': channel.type
+        }
+    if isinstance(channel, discord.VoiceChannel):
         return {
             'name': channel.name,
             'position': channel.position,

--- a/discord/ext/test/voice.py
+++ b/discord/ext/test/voice.py
@@ -1,0 +1,35 @@
+from typing import Callable
+
+from discord import Client, VoiceClient
+from discord.abc import Connectable, T
+from discord.channel import VoiceChannel
+
+
+class FakeVoiceClient(VoiceClient):
+    """
+    Mock implementation of a Discord VoiceClient. VoiceClient.connect tries to contact the Discord API and is called
+    whenever connect() is called on a VoiceChannel, so we need to override that method and pass in the fake version
+    to prevent the program from actually making calls to the Discord API.
+    """
+    async def connect(self, *, reconnect: bool, timeout: float, self_deaf: bool = False,
+                      self_mute: bool = False) -> None:
+        self._connected.set()
+
+
+class FakeVoiceChannel(VoiceChannel):
+    """
+    Mock implementation of a Discord VoiceChannel. Exists just to pass a FakeVoiceClient into the superclass connect()
+    method.
+    """
+
+    async def connect(
+            self,
+            *,
+            timeout: float = 60.0,
+            reconnect: bool = True,
+            cls: Callable[[Client, Connectable], T] = FakeVoiceClient,
+            self_deaf: bool = False,
+            self_mute: bool = False,
+    ) -> T:
+        return await super().connect(timeout=timeout, reconnect=reconnect, cls=cls, self_deaf=self_deaf,
+                                     self_mute=self_mute)

--- a/tests/test_create_channel.py
+++ b/tests/test_create_channel.py
@@ -1,0 +1,28 @@
+import pytest
+import discord
+import discord.ext.test as dpytest
+
+
+@pytest.mark.asyncio
+async def test_create_voice_channel(bot):
+    guild = bot.guilds[0]
+    http = bot.http
+
+    # create_channel checks the value of variables in the parent call context, so we need to set these for it to work
+    self = guild  # noqa: F841
+    name = "voice_channel_1"
+    channel = await http.create_channel(guild, channel_type=discord.ChannelType.voice.value)
+    assert channel['type'] == discord.ChannelType.voice
+    assert channel['name'] == name
+
+
+@pytest.mark.asyncio
+async def test_make_voice_channel(bot):
+    guild = bot.guilds[0]
+    bitrate = 100
+    user_limit = 5
+    channel = dpytest.backend.make_voice_channel("voice", guild, bitrate=bitrate, user_limit=user_limit)
+    assert channel.name == "voice"
+    assert channel.guild == guild
+    assert channel.bitrate == bitrate
+    assert channel.user_limit == user_limit

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -1,0 +1,29 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_bot_join_voice(bot):
+    assert not bot.voice_clients
+    await bot.guilds[0].voice_channels[0].connect()
+    assert bot.voice_clients
+
+
+@pytest.mark.asyncio
+async def test_bot_leave_voice(bot):
+    voice_client = await bot.guilds[0].voice_channels[0].connect()
+    await voice_client.disconnect()
+    assert not bot.voice_clients
+
+
+@pytest.mark.asyncio
+async def test_move_member(bot):
+    guild = bot.guilds[0]
+    voice_channel = guild.voice_channels[0]
+    member = guild.members[0]
+
+    assert member.voice is None
+    await member.move_to(voice_channel)
+    assert member.voice.channel == voice_channel
+
+    await member.move_to(None)
+    assert member.voice is None


### PR DESCRIPTION
While testing my bot, I ran into issues because some of its functionality relies on joining/leaving voice channels or checking the voice state of users. To remedy this, I've implemented the FakeVoiceChannel and FakeVoiceClient classes, in addition to creating a callback for edit_member and expanded the create_channel method to cover voice channels. I've included some tests for the new feature.

Please let me know if you think there's anything missing or incorrect in my PR. Thanks!