### PR TITLE
Improve documentation: make message queue cleaning clearer

### DIFF
--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -44,6 +44,10 @@ it goes into the ``discord.py`` extensions module. So, the most basic usage of d
     asyncio.run(test_ping())
     asyncio.run(test_foo())
 
+One problem that could happen is that the ``sent_queue`` is shared between the tests. So in order not to mess between
+your tests (``verify()`` pops **one** message from the queue, so in general, you won't need to do anything) you can
+explicitly call ``empty_queue()``, as shown in the next example (and later, in the ``conftests.py``).
+
 If that looks like a lot of code just to run tests, don't worry, there's a better way! We can use pytest,
 a popular Python testing library.
 

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -32,6 +32,7 @@ it goes into the ``discord.py`` extensions module. So, the most basic usage of d
         dpytest.configure(bot)
         await dpytest.message("!ping")
         assert dpytest.verify().message().contains().content("Ping:")
+        await dpytest.empty_queue() # empty the global message queue as test teardown
 
 
     async def test_foo():
@@ -39,6 +40,7 @@ it goes into the ``discord.py`` extensions module. So, the most basic usage of d
         dpytest.configure(bot)
         await dpytest.message("!hello")
         assert dpytest.verify().message().content("Hello World!")
+        await dpytest.empty_queue() # empty the global message queue as test teardown
 
 
     asyncio.run(test_ping())

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -32,7 +32,6 @@ it goes into the ``discord.py`` extensions module. So, the most basic usage of d
         dpytest.configure(bot)
         await dpytest.message("!ping")
         assert dpytest.verify().message().contains().content("Ping:")
-        await dpytest.empty_queue() # empty the global message queue as test teardown
 
 
     async def test_foo():
@@ -40,7 +39,6 @@ it goes into the ``discord.py`` extensions module. So, the most basic usage of d
         dpytest.configure(bot)
         await dpytest.message("!hello")
         assert dpytest.verify().message().content("Hello World!")
-        await dpytest.empty_queue() # empty the global message queue as test teardown
 
 
     asyncio.run(test_ping())

--- a/docs/tutorials/using_pytest.rst
+++ b/docs/tutorials/using_pytest.rst
@@ -17,8 +17,9 @@ as:
 
 ``pytest`` will detect any functions starting with 'test' in directories it searches, and run them. It also supports
 a feature we will use heavily, called 'fixtures'. Fixtures are functions that do some common test setup, and
-then can be used in tests to always perform that setup. They can also return an object that will be passed to
-the test.
+then can be used in tests to always perform that setup, they can also return an object that will be passed to
+the test. Finally, they allow you to perform test teardown, cleaning message queue for example.
+See https://docs.pytest.org/en/latest/how-to/fixtures.html#teardown-cleanup-aka-fixture-finalization
 
 The final piece of this is ``pytest-asyncio``, a library for allowing ``pytest`` to run async tests. It is
 automatically installed when you get ``dpytest`` from pip, so you don't need to worry about installing it.

--- a/docs/tutorials/using_pytest.rst
+++ b/docs/tutorials/using_pytest.rst
@@ -47,6 +47,7 @@ Putting all this together, we can rewrite our previous tests to look like this:
 
     @pytest_asyncio.fixture
     async def bot():
+        # Setup
         intents = discord.Intents.default()
         intents.members = True
         intents.message_content = True
@@ -56,7 +57,11 @@ Putting all this together, we can rewrite our previous tests to look like this:
         await b.add_cog(Misc())
 
         dpytest.configure(b)
-        return b
+
+        yield b
+
+        # Teardown
+        await dpytest.empty_queue() # empty the global message queue as test teardown
 
 
     @pytest.mark.asyncio
@@ -99,6 +104,7 @@ An example ``conftest.py`` might look like this:
 
     @pytest_asyncio.fixture
     async def bot():
+        # Setup
         intents = discord.Intents.default()
         intents.members = True
         intents.message_content = True
@@ -106,12 +112,11 @@ An example ``conftest.py`` might look like this:
                         intents=intents)
         await b._async_setup_hook()
         dpytest.configure(b)
-        return b
 
+        yield b
 
-    @pytest_asyncio.fixture(autouse=True)
-    async def cleanup():
-        await dpytest.empty_queue()
+        # Teardown
+        await dpytest.empty_queue() # empty the global message queue as test teardown
 
 
     def pytest_sessionfinish(session, exitstatus):

--- a/docs/tutorials/using_pytest.rst
+++ b/docs/tutorials/using_pytest.rst
@@ -143,6 +143,12 @@ Troubleshooting
 Make sure your tests take a parameter with the exact same name as the fixture,
 pytest runs them based on name, including capitalization.
 
+- I use dpytest.verify().message() and it fails but it shouldn't
+- dpytest.get_message() returns a message from another test
+
+Make sure you properly emptied the queue in the previous test, otherwise you
+could have remaining messages from previous tests messing up.
+
 --------------------
 
 This is currently the end of the tutorials. Take a look at the `Runner Documentation`_ to see all the things you can


### PR DESCRIPTION
Should fix #116 

According to me, this is the least that should be done to help the new user deal with message queue, the must would be to perform it automatically.

However I'm still not sure about a few changes:
- [ ] have I updated everything that should be?
- [ ] is there other queues that should be emptied? `send_queue`, `error_queue`?
- [ ] in #116 we didn't speak of the tuto without pytest but it should suffer the same issue right?
- [ ] I tried to improve the paragraph introducing fixture to talk about tear down/cleaning, which is what we're using here
- [ ] I added a troubleshooting case, the more explicit I could, to help future users that could encounter the issue I encountered

I separated my changes in different commits to help you walking through the reviewing process.

Don't hesitate to reject or discuss any changes I propose :wink: